### PR TITLE
fix models because the gradient clip strategy has been upgraded

### DIFF
--- a/examples/clarinet/train.py
+++ b/examples/clarinet/train.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
         optim = fluid.optimizer.Adam(
             lr_scheduler, parameter_list=model.parameters())
         gradiant_max_norm = train_config["gradient_max_norm"]
-        clipper = fluid.dygraph_grad_clip.GradClipByGlobalNorm(
+        clipper = fluid.clip.GradientClipByGlobalNorm(
             gradiant_max_norm)
 
         # train

--- a/examples/clarinet/train.py
+++ b/examples/clarinet/train.py
@@ -163,11 +163,10 @@ if __name__ == "__main__":
         anneal_interval = train_config["anneal_interval"]
         lr_scheduler = dg.ExponentialDecay(
             learning_rate, anneal_interval, anneal_rate, staircase=True)
-        optim = fluid.optimizer.Adam(
-            lr_scheduler, parameter_list=model.parameters())
         gradiant_max_norm = train_config["gradient_max_norm"]
-        clipper = fluid.clip.GradientClipByGlobalNorm(
-            gradiant_max_norm)
+        clipper = fluid.clip.GradientClipByGlobalNorm(gradiant_max_norm)
+        optim = fluid.optimizer.Adam(
+            lr_scheduler, parameter_list=model.parameters(), grad_clip=clipper)
 
         # train
         max_iterations = train_config["max_iterations"]
@@ -229,7 +228,7 @@ if __name__ == "__main__":
                                                                   step_loss))
 
             l.backward()
-            optim.minimize(l, grad_clip=clipper)
+            optim.minimize(l)
             optim.clear_gradients()
 
             if global_step % eval_interval == 0:

--- a/examples/deepvoice3/train.py
+++ b/examples/deepvoice3/train.py
@@ -191,13 +191,14 @@ if __name__ == "__main__":
         beta1 = optim_config["beta1"]
         beta2 = optim_config["beta2"]
         epsilon = optim_config["epsilon"]
+        gradient_clipper = fluid.clip.GradientClipByGlobalNorm(0.1)
         optim = fluid.optimizer.Adam(
             lr_scheduler,
             beta1,
             beta2,
             epsilon=epsilon,
-            parameter_list=dv3.parameters())
-        gradient_clipper = fluid.clip.GradientClipByGlobalNorm(0.1)
+            parameter_list=dv3.parameters(),
+            grad_clip=gradient_clipper)
 
         # generation
         synthesis_config = config["synthesis"]
@@ -261,7 +262,7 @@ if __name__ == "__main__":
             # record learning rate before updating
             writer.add_scalar("learning_rate",
                               optim._learning_rate.step().numpy(), global_step)
-            optim.minimize(l, grad_clip=gradient_clipper)
+            optim.minimize(l)
             optim.clear_gradients()
 
             # ==================all kinds of tedious things=================

--- a/examples/deepvoice3/train.py
+++ b/examples/deepvoice3/train.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
             beta2,
             epsilon=epsilon,
             parameter_list=dv3.parameters())
-        gradient_clipper = fluid.dygraph_grad_clip.GradClipByGlobalNorm(0.1)
+        gradient_clipper = fluid.clip.GradientClipByGlobalNorm(0.1)
 
         # generation
         synthesis_config = config["synthesis"]

--- a/examples/fastspeech/train.py
+++ b/examples/fastspeech/train.py
@@ -169,7 +169,7 @@ def main(args):
                     total_loss.backward()
                 optimizer.minimize(
                     total_loss,
-                    grad_clip=fluid.dygraph_grad_clip.GradClipByGlobalNorm(cfg[
+                    grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
                         'grad_clip_thresh']))
                 model.clear_gradients()
 

--- a/examples/fastspeech/train.py
+++ b/examples/fastspeech/train.py
@@ -79,7 +79,9 @@ def main(args):
         optimizer = fluid.optimizer.AdamOptimizer(
             learning_rate=dg.NoamDecay(1 / (
                 cfg['warm_up_step'] * (args.lr**2)), cfg['warm_up_step']),
-            parameter_list=model.parameters())
+            parameter_list=model.parameters(),
+            grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
+                        'grad_clip_thresh']))
         reader = LJSpeechLoader(
             cfg, args, nranks, local_rank, shuffle=True).reader()
 
@@ -167,10 +169,7 @@ def main(args):
                     model.apply_collective_grads()
                 else:
                     total_loss.backward()
-                optimizer.minimize(
-                    total_loss,
-                    grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
-                        'grad_clip_thresh']))
+                optimizer.minimize(total_loss)
                 model.clear_gradients()
 
                 # save checkpoint

--- a/examples/transformer_tts/train_transformer.py
+++ b/examples/transformer_tts/train_transformer.py
@@ -185,7 +185,7 @@ def main(args):
                     loss.backward()
                 optimizer.minimize(
                     loss,
-                    grad_clip=fluid.dygraph_grad_clip.GradClipByGlobalNorm(cfg[
+                    grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
                         'grad_clip_thresh']))
                 model.clear_gradients()
 

--- a/examples/transformer_tts/train_transformer.py
+++ b/examples/transformer_tts/train_transformer.py
@@ -66,7 +66,9 @@ def main(args):
         optimizer = fluid.optimizer.AdamOptimizer(
             learning_rate=dg.NoamDecay(1 / (
                 cfg['warm_up_step'] * (args.lr**2)), cfg['warm_up_step']),
-            parameter_list=model.parameters())
+            parameter_list=model.parameters(),
+            grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
+                        'grad_clip_thresh']))
 
         if args.checkpoint_path is not None:
             model_dict, opti_dict = load_checkpoint(
@@ -183,10 +185,7 @@ def main(args):
                     model.apply_collective_grads()
                 else:
                     loss.backward()
-                optimizer.minimize(
-                    loss,
-                    grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
-                        'grad_clip_thresh']))
+                optimizer.minimize(loss)
                 model.clear_gradients()
 
                 # save checkpoint

--- a/examples/transformer_tts/train_vocoder.py
+++ b/examples/transformer_tts/train_vocoder.py
@@ -103,7 +103,7 @@ def main(args):
                     loss.backward()
                 optimizer.minimize(
                     loss,
-                    grad_clip=fluid.dygraph_grad_clip.GradClipByGlobalNorm(cfg[
+                    grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
                         'grad_clip_thresh']))
                 model.clear_gradients()
 

--- a/examples/transformer_tts/train_vocoder.py
+++ b/examples/transformer_tts/train_vocoder.py
@@ -64,7 +64,9 @@ def main(args):
         optimizer = fluid.optimizer.AdamOptimizer(
             learning_rate=dg.NoamDecay(1 / (
                 cfg['warm_up_step'] * (args.lr**2)), cfg['warm_up_step']),
-            parameter_list=model.parameters())
+            parameter_list=model.parameters(),
+            grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
+                        'grad_clip_thresh']))
 
         if args.checkpoint_path is not None:
             model_dict, opti_dict = load_checkpoint(
@@ -101,10 +103,7 @@ def main(args):
                     model.apply_collective_grads()
                 else:
                     loss.backward()
-                optimizer.minimize(
-                    loss,
-                    grad_clip=fluid.clip.GradientClipByGlobalNorm(cfg[
-                        'grad_clip_thresh']))
+                optimizer.minimize(loss)
                 model.clear_gradients()
 
                 if local_rank == 0:

--- a/examples/wavenet/train.py
+++ b/examples/wavenet/train.py
@@ -126,12 +126,10 @@ if __name__ == "__main__":
         anneal_interval = train_config["anneal_interval"]
         lr_scheduler = dg.ExponentialDecay(
             learning_rate, anneal_interval, anneal_rate, staircase=True)
-        optim = fluid.optimizer.Adam(
-            lr_scheduler, parameter_list=model.parameters())
-
         gradiant_max_norm = train_config["gradient_max_norm"]
-        clipper = fluid.clip.GradientClipByGlobalNorm(
-            gradiant_max_norm)
+        clipper = fluid.clip.GradientClipByGlobalNorm(gradiant_max_norm)
+        optim = fluid.optimizer.Adam(
+            lr_scheduler, parameter_list=model.parameters(), grad_clip=clipper)
 
         train_loader = fluid.io.DataLoader.from_generator(
             capacity=10, return_list=True)
@@ -181,7 +179,7 @@ if __name__ == "__main__":
             writer.add_scalar("learning_rate",
                               optim._learning_rate.step().numpy()[0],
                               global_step)
-            optim.minimize(loss_var, grad_clip=clipper)
+            optim.minimize(loss_var)
             optim.clear_gradients()
             print("global_step: {}\tloss: {:<8.6f}".format(global_step,
                                                            loss_np[0]))

--- a/examples/wavenet/train.py
+++ b/examples/wavenet/train.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
             lr_scheduler, parameter_list=model.parameters())
 
         gradiant_max_norm = train_config["gradient_max_norm"]
-        clipper = fluid.dygraph_grad_clip.GradClipByGlobalNorm(
+        clipper = fluid.clip.GradientClipByGlobalNorm(
             gradiant_max_norm)
 
         train_loader = fluid.io.DataLoader.from_generator(


### PR DESCRIPTION
梯度裁剪的策略在1.8.0中已经升级  https://github.com/PaddlePaddle/Paddle/pull/23224

移除了dygraph_grad_clip的接口。

该PR修复了dygraph_grad_clip不兼容的地方，并迁移到了新接口。

```
fluid.clip.GradientClipByGlobalNorm(clip_norm,need_clip=None)
fluid.clip.GradientClipByNorm(clip_norm,need_clip=None)
fluid.clip.GradientClipByValue(min,max,need_clip=None)
```