### PR TITLE
remove tabs in default config file to avoid parsing error

### DIFF
--- a/examples/parallelwave_gan/baker/conf/default.yaml
+++ b/examples/parallelwave_gan/baker/conf/default.yaml
@@ -125,4 +125,4 @@ eval_interval_steps: 1000               # Interval steps to evaluate the network
 ###########################################################
 num_save_intermediate_results: 4  # Number of results to be saved as intermediate results.
 num_snapshots: 10                 # max number of snapshots to keep while training
-seed: 42	                  # random seed for paddle, random, and np.random
+seed: 42                          # random seed for paddle, random, and np.random


### PR DESCRIPTION
remove tabs in default config file to avoid parsing error