### PR TITLE
add sclite test for text_frontend

### DIFF
--- a/examples/text_frontend/README.md
+++ b/examples/text_frontend/README.md
@@ -11,6 +11,10 @@ For text normalization, the test data is  `data/textnorm_test_cases.txt`, we use
 
 We use `CER` as evaluation criterion.
 ## Start
+If you want to use sclite to get more detail information of WER, you should run the command below to make sclite first.
+```bash
+./make_sclite.sh
+```
 Run the command below to get the results of test.
 ```bash
 ./run.sh

--- a/examples/text_frontend/make_sclite.sh
+++ b/examples/text_frontend/make_sclite.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ ! -d "./SCTK" ];then
+    echo "Clone SCTK ..."
+    git clone https://github.com/usnistgov/SCTK
+    echo "Clone SCTK done!"
+fi
+
+if [ ! -d "./SCTK/bin" ];then
+    echo "Start make SCTK ..."
+    pushd SCTK && make config && make all && make check && make install && make doc && popd
+    echo "SCTK make done!"
+fi

--- a/examples/text_frontend/run.sh
+++ b/examples/text_frontend/run.sh
@@ -1,19 +1,7 @@
 #!/bin/bash
+
 USE_SCLITE=true
 
-if [ "$USE_SCLITE" = true ];then
-    if [ ! -d "./SCTK" ];then
-        echo "Clone SCTK ..."
-        git clone https://github.com/usnistgov/SCTK
-        echo "Clone SCTK done!"
-    fi
-
-    if [ ! -d "./SCTK/bin" ];then
-        echo "Start make SCTK ..."
-        pushd SCTK && make config && make all && make check && make install && make doc && popd
-        echo "SCTK make done!"
-    fi
-fi
 # test g2p
 echo "Start get g2p test data ..."
 python3 get_g2p_data.py --root-dir=~/datasets/BZNSYP --output-dir=data/g2p
@@ -29,9 +17,9 @@ python3 test_textnorm.py --input-dir=data/textnorm --output-dir=exp/textnorm
 # whether use sclite to get more detail information of WER
 if [ "$USE_SCLITE" = true ];then
     echo "Start sclite g2p ..."
-    ./SCTK/bin/sclite -i wsj -r ./exp/g2p/text.ref.clean -h ./exp/g2p/text.g2p -e utf-8 -o all
+    ./SCTK/bin/sclite -i wsj -r ./exp/g2p/text.ref.clean trn -h ./exp/g2p/text.g2p trn -e utf-8 -o all
     echo
 
     echo "Start sclite textnorm ..."
-    ./SCTK/bin/sclite -i wsj -r ./exp/textnorm/text.ref.clean -h ./exp/textnorm/text.tn -e utf-8 -o all
+    ./SCTK/bin/sclite -i wsj -r ./exp/textnorm/text.ref.clean trn -h ./exp/textnorm/text.tn trn -e utf-8 -o all
 fi

--- a/examples/text_frontend/run.sh
+++ b/examples/text_frontend/run.sh
@@ -1,14 +1,37 @@
 #!/bin/bash
+USE_SCLITE=true
 
+if [ "$USE_SCLITE" = true ];then
+    if [ ! -d "./SCTK" ];then
+        echo "Clone SCTK ..."
+        git clone https://github.com/usnistgov/SCTK
+        echo "Clone SCTK done!"
+    fi
+
+    if [ ! -d "./SCTK/bin" ];then
+        echo "Start make SCTK ..."
+        pushd SCTK && make config && make all && make check && make install && make doc && popd
+        echo "SCTK make done!"
+    fi
+fi
 # test g2p
-echo "Start get g2p test data."
+echo "Start get g2p test data ..."
 python3 get_g2p_data.py --root-dir=~/datasets/BZNSYP --output-dir=data/g2p
-echo "Start test g2p."
+echo "Start test g2p ..."
 python3 test_g2p.py --input-dir=data/g2p --output-dir=exp/g2p
 
 # test text normalization
-echo "Start get text normalization test data."
+echo "Start get text normalization test data ..."
 python3 get_textnorm_data.py --test-file=data/textnorm_test_cases.txt --output-dir=data/textnorm
-echo "Start test text normalization."
+echo "Start test text normalization ..."
 python3 test_textnorm.py --input-dir=data/textnorm --output-dir=exp/textnorm
 
+# whether use sclite to get more detail information of WER
+if [ "$USE_SCLITE" = true ];then
+    echo "Start sclite g2p ..."
+    ./SCTK/bin/sclite -i wsj -r ./exp/g2p/text.ref.clean -h ./exp/g2p/text.g2p -e utf-8 -o all
+    echo
+
+    echo "Start sclite textnorm ..."
+    ./SCTK/bin/sclite -i wsj -r ./exp/textnorm/text.ref.clean -h ./exp/textnorm/text.tn -e utf-8 -o all
+fi

--- a/examples/text_frontend/test_g2p.py
+++ b/examples/text_frontend/test_g2p.py
@@ -47,8 +47,8 @@ def get_avg_wer(raw_dict, ref_dict, frontend, output_dir):
         gt_phones = [phn for phn in gt_phones if phn not in SILENCE_TOKENS]
         gt_phones = " ".join(gt_phones)
         g2p_phones = " ".join(g2p_phones)
-        wf_ref.write(utt_id + " " + gt_phones + "\n")
-        wf_g2p.write(utt_id + " " + g2p_phones + "\n")
+        wf_ref.write(gt_phones + "(baker_" + utt_id + ")" + "\n")
+        wf_g2p.write(g2p_phones + "(baker_" + utt_id + ")" + "\n")
         edit_distance, ref_len = word_errors(gt_phones, g2p_phones)
         edit_distances.append(edit_distance)
         ref_lens.append(ref_len)

--- a/examples/text_frontend/test_textnorm.py
+++ b/examples/text_frontend/test_textnorm.py
@@ -43,8 +43,8 @@ def get_avg_cer(raw_dict, ref_dict, text_normalizer, output_dir):
 
         gt_text = del_en_add_space(gt_text)
         textnorm_text = del_en_add_space(textnorm_text)
-        wf_ref.write(text_id + " " + gt_text + "\n")
-        wf_tn.write(text_id + " " + textnorm_text + "\n")
+        wf_ref.write(gt_text + "(" + text_id + ")" + "\n")
+        wf_tn.write(textnorm_text + "(" + text_id + ")" + "\n")
         edit_distance, ref_len = char_errors(gt_text, textnorm_text)
         edit_distances.append(edit_distance)
         ref_lens.append(ref_len)


### PR DESCRIPTION
1. the scoring report of g2p
![g2p_sys](https://user-images.githubusercontent.com/24568452/130316138-240768dc-ac62-4d01-aec2-b87ba5d7c6f7.png)

2. part of the string alignments of g2p
![g2p_pra](https://user-images.githubusercontent.com/24568452/130316147-056086f5-4f54-4159-9a67-cad216a791af.png)

3. the scoring report of textnorm
![tn_sys](https://user-images.githubusercontent.com/24568452/130316152-523d26bf-931b-486a-878f-deec162d3bb8.png)

4. part of the string alignments of textnorm
![tn_pra](https://user-images.githubusercontent.com/24568452/130316165-48e47dee-9d44-4cee-91bc-e8b80e55adec.png)

We can find that there are more than 50% sentences in g2p test have errors, and they're almost substitution errors.